### PR TITLE
md_transforms: img, parse a border property.

### DIFF
--- a/sphinx_lesson/_static/sphinx_lesson.css
+++ b/sphinx_lesson/_static/sphinx_lesson.css
@@ -1,1 +1,5 @@
 /* sphinx_lesson.css */
+
+body.wy-body-for-nav img.with-border {
+    border: 2px solid;
+}

--- a/sphinx_lesson/md_transforms.py
+++ b/sphinx_lesson/md_transforms.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import textwrap
 
 from docutils import nodes
 from docutils.parsers.rst.directives.admonitions \
@@ -136,10 +137,19 @@ def transform_html_img(app, docname, source):
 
     def sub_img(m):
         """Handle each detected block quote"""
-        repl = """
-```{figure} %(src)s
-```
-"""%{'src':m.group('src')}
+        raw = m.group(0)
+        if re.search(r'style="[^"]*border:', raw):
+            border = textwrap.dedent("""\
+                ---
+                class: with-border
+                ---
+                """)
+        else:
+            border = ""
+        repl = textwrap.dedent("""
+            ```{figure} %(src)s
+            %(border)s```
+            """)%{'src':m.group('src'), 'border': border}
         LOG.debug(repl)
         return repl
 


### PR DESCRIPTION
- If `<img>` matches `style=*"border:`, then apply the CSS class
  `with-border`.

- Define the `with-border` css class to add a 2px solid border
  (hardcoded, does not parse the actual style at all).

- The raw directive-based equivalent in markdown is this:

  ~~~~~~~~
  ```{figure} /img/doi/publish-release.png
  ---
  class: with-border
  ---
  ```
  ~~~~~~~~