### PR TITLE
jupyter: document recursive myst_parser execution.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -43,8 +43,9 @@ extensions = [
 # Settings for myst_nb:
 # https://myst-nb.readthedocs.io/en/latest/use/execute.html#triggering-notebook-execution
 #jupyter_execute_notebooks = "off"
-jupyter_execute_notebooks = "auto"
+#jupyter_execute_notebooks = "auto"   # *only* execute if at least one output is missing.
 #jupyter_execute_notebooks = "force"
+jupyter_execute_notebooks = "cache"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/jupyter.ipynb
+++ b/jupyter.ipynb
@@ -9,20 +9,44 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cs-012\r\n"
-     ]
-    }
-   ],
    "source": [
-    "!hostname"
+    "## Usage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Basic code execution works:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!hostname\n",
+    "print(sum(range(10)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Directives work as well, since it is recursively executed by the same parser as normal Markdown files.  Of course, Sphinx directives won't be interperted within Jupyter itself, but that is probably OK for development purposes:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{challenge}\n",
+    "\n",
+    "This is a challenge block\n",
+    "```"
    ]
   },
   {
@@ -31,6 +55,27 @@
    "source": [
     "You can learn more about this at the [myst-nb docs](https://myst-nb.readthedocs.io/en/latest/use/execute.html).  Most this applies equally to the `.md` files."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "The `jupyter_execute_notebooks` variable in conf.py controls execution.  Currently, we don't set a default for this, which makes it `auto`.  You can read more about this [upstream](https://myst-nb.readthedocs.io/en/latest/use/execute.html).  Possible values include:\n",
+    "\n",
+    "* `off`: don't execute\n",
+    "* `auto`: exceute *only if there are missing outputs\n",
+    "* `force`: always re-execute\n",
+    "* `cache`: always execute, but cache the output. Don't re-execute if the input is unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -49,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- The myst_parser runs on the markdown cells in Jupyter Notebooks, so
  that you can use all of the normal directives in there.
- Clarify how you control execution of notebooks.  I got confused when
  it wasn't executing when outputs were already present.