### PR TITLE
.github/workflows/sphinx: Don't keep gh-pages history

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -100,4 +100,4 @@ jobs:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _gh-pages/
-          #force_orphan: true
+          force_orphan: true


### PR DESCRIPTION
- Each gh-pages push now makes a new disconnected branch.  This saves
  space by discarding history.

- Perhaps the history isn't needed?  But...

  - Each branch is built and included in gh-pages, in the
    branch/$branch-name/ subdir (except the default branch).  So, that
    means we *have* to keep history, or else we lose these branches
    (we don't build every branch on every push).  Right now the action
    handles that by checking out old gh-pages, inserting the new
    build, and pushing.  This change removes that history.

  - I'm not sure if there will be some weird interactions and
    something will break, but I guess we can try it and see?