### PR TITLE
sphinx-togglebutton: Make solution admonitions collapsed by default

### DIFF
--- a/directives.rst
+++ b/directives.rst
@@ -10,7 +10,7 @@ We have the following directives available:
 * ``keypoints``
 * ``objectives``
 * ``prereq``
-* ``solution``
+* ``solution`` (begins collapsed)
 * ``testimonial``
 * ``output``
 * ``questions``
@@ -38,6 +38,13 @@ Example of ``challenge``:
 
 	    Some body text
 
+
+The ``solution`` directive begins collapsed (via `sphinx-togglebutton
+<https://github.com/executablebooks/sphinx-togglebutton>`__:
+
+.. solution::
+
+   This is a solution
 
 Directives are implemented in the Python package
 ``sphinx_lesson.directives`` and can be used independently of the rest

--- a/installation.rst
+++ b/installation.rst
@@ -42,5 +42,6 @@ Adding ``sphinx_lesson`` as an extension adds these sub-extensions:
   * Enables the `sphinx-copybutton extension
     <https://github.com/executablebooks/sphinx-copybutton>`__
     (included as a dependency)
+  * Same for `sphinx-togglebutton <https://pypi.org/project/sphinx-togglebutton/>`__
 
 Any of these can be used independently to get the same effect.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 sphinx_rtd_theme
 sphinx_copybutton
+sphinx_togglebutton>=0.2.0
 #myst_parser[sphinx]
 myst_nb>0.8.3

--- a/sphinx_lesson/__init__.py
+++ b/sphinx_lesson/__init__.py
@@ -4,6 +4,7 @@ def setup(app):
     "Sphinx extension setup"
     app.setup_extension('myst_nb')
     app.setup_extension('sphinx_copybutton')
+    app.setup_extension('sphinx_togglebutton')
     app.setup_extension(__name__+'.directives')
     app.setup_extension(__name__+'.md_transforms')
 

--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -21,6 +21,7 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
     required_arguments = 0
     optional_arguments = 1
     final_argument_whitespace = True
+    extra_classes = [ ]
 
     @classmethod
     def cssname(cls):
@@ -53,6 +54,7 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
         ret = super().run()
         # Set CSS classes
         ret[0].attributes['classes'].append(name)
+        ret[0].attributes['classes'].extend(self.extra_classes)
         return ret
 
 
@@ -64,7 +66,8 @@ class KeypointsDirective(_BaseCRDirective): pass
 class ObjectivesDirective(_BaseCRDirective): pass
 class PrereqDirective(_BaseCRDirective):
     title_text = "Prerequisites"
-class SolutionDirective(_BaseCRDirective): pass
+class SolutionDirective(_BaseCRDirective):
+    extra_classes = ['dropdown'] #'toggle-shown' = visible by default
 class TestimonialDirective(_BaseCRDirective): pass
 class OutputDirective(_BaseCRDirective):
     title_text = 'Output'


### PR DESCRIPTION
- Add this extensions as a hard dependency and sets up the `solution`
  to start collapsed by default.
- https://github.com/executablebooks/sphinx-togglebutton
- Review: general check unless someone wants to takelocally and
  compile it.  A test is in the docs: directives.rst