### PR TITLE
.github/workflows/sphinx: Fetch before we branch gh-pages

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -49,6 +49,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           set -x
+          git fetch
           ( git branch gh-pages remotes/origin/gh-pages && git clone . --branch=gh-pages _gh-pages/ ) || mkdir _gh-pages
           rm -rf _gh-pages/.git/
           mkdir -p _gh-pages/branch/


### PR DESCRIPTION
- This should reduce the window of a race condition when multiple
  deploys occur within a short time of each other.  It doesn't
  entirely fix it, but should reduce the window in which it can
  happen...