### PR TITLE
.github/workflows/sphinx: Add commented option for strict builds

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -3,6 +3,12 @@
 name: sphinx
 on: [push, pull_request]
 
+# If these SPHINXOPTS are enabled, then be strict about the builds and
+# fail on any warnings
+#env:
+#  SPHINXOPTS: "-W --keep-going -T"
+
+
 jobs:
   build-and-deploy:
     name: Build and gh-pages


### PR DESCRIPTION
- Strict builds may be desired by some projects
- This adds the option in an easy to find place, but leaves it commented out.