### PR TITLE
.github/workflows/sphinx: Add .nojekyll file

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -97,6 +97,12 @@ jobs:
               fi
           done
 
+      # Add the .nojekyll file
+      - name: nojekyll
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          touch _gh-pages/.nojekyll
+
       # Deploy
       # https://github.com/peaceiris/actions-gh-pages
       - name: Deploy


### PR DESCRIPTION
- This could also be added by Sphinx, but I figure that since we
  combine multiple sphinx builds (for the branches), this is the more
  appropriate abstraction layer to create the file.
- Review: quick check, does CI pass and it appears in the build?