### PR TITLE
sphinx_lesson/__init__: Enable minipres by default

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -46,7 +46,6 @@ extensions = [
     #'myst_nb',  # now done as part of sphinx_lesson
     #'sphinx.ext.intersphinx',
     'sphinx_rtd_theme_ext_color_contrast',
-    'sphinx_minipres',
 ]
 
 # Settings for myst_nb:

--- a/sphinx_lesson/__init__.py
+++ b/sphinx_lesson/__init__.py
@@ -4,6 +4,7 @@ def setup(app):
     "Sphinx extension setup"
     app.setup_extension('myst_nb')
     app.setup_extension('sphinx_copybutton')
+    app.setup_extension('sphinx_minipres')
     app.setup_extension('sphinx_tabs.tabs')
     app.setup_extension('sphinx_togglebutton')
     app.setup_extension(__name__+'.directives')


### PR DESCRIPTION
- It was supposed to be enabled, but wasn't.
- Review: does CI pass?