### PR TITLE
sphinx_lesson/directives: Make exercises and solutions "important"

### DIFF
--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -60,7 +60,8 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
 
 
 class CalloutDirective(_BaseCRDirective): pass
-class ChallengeDirective(_BaseCRDirective): pass
+class ChallengeDirective(_BaseCRDirective):
+    extra_classes = ['important']
 class ChecklistDirective(_BaseCRDirective): pass
 class DiscussionDirective(_BaseCRDirective): pass
 class KeypointsDirective(_BaseCRDirective): pass
@@ -68,7 +69,7 @@ class ObjectivesDirective(_BaseCRDirective): pass
 class PrereqDirective(_BaseCRDirective):
     title_text = "Prerequisites"
 class SolutionDirective(_BaseCRDirective):
-    extra_classes = ['dropdown'] #'toggle-shown' = visible by default
+    extra_classes = ['important', 'dropdown'] #'toggle-shown' = visible by default
 class TestimonialDirective(_BaseCRDirective): pass
 class OutputDirective(_BaseCRDirective):
     title_text = 'Output'


### PR DESCRIPTION
- In sphinx_rtd_theme, these become green-colored boxes
- This is an old, uncommitted change: feel free to not use it if best
  practice has moved on.
- Review: is this even a good idea for a color scheme?