### PR TITLE
requirements: Bugfix with docutils==0.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+docutils<0.17   # Bug with sphinx<=3.5.3/docutils==0.17, remove later
 sphinx
 sphinx_rtd_theme
 sphinx_copybutton


### PR DESCRIPTION
- Docutils==0.17 have some changes that break Sphinx rendering.
  Sphinx is working on it, but in the meantime we can fix some
  dependencies here until everything gets resolved.  This will also
  fix everyone that depends on us.
- This will be removed later, once most Sphinx installations get
  updated to handle it.
- https://github.com/sphinx-doc/sphinx/issues/9061
- I propose a release soon after this
- Review:
  - General check
  - comment on release
  - comments on the general way we manage the requirements here?