### PR TITLE
Standardize and color directives

### DIFF
--- a/content/directives.rst
+++ b/content/directives.rst
@@ -106,8 +106,9 @@ They all render as green ("important" class:
 
 Other miscellaneous directives:
 
-* ``prerequisites``
+* ``discussion``
 * ``instructor-note``
+* ``prerequisites``
 
 The following are Sphinx default directives that may be especially
 useful to lessons.  These do *not* accept an optional Title argument,
@@ -125,7 +126,6 @@ The following are available, for compatibility with Carpentries styles:
 * ``callout``
 * ``challenge`` (alias to ``exercise``)
 * ``checklist``
-* ``discussion``
 * ``keypoints`` (bottom of lesson)
 * ``objectives`` (top of lesson)
 * ``prereq`` (use ``prerequisites`` instead)
@@ -167,6 +167,10 @@ sphinx-lesson
 .. homework::
 
    homework
+
+.. discussion::
+
+   discussion
 
 .. instructor-note::
 
@@ -229,10 +233,6 @@ Carpentries holdovers
 .. prereq::
 
    prereq
-
-.. discussion::
-
-   discussion
 
 .. testimonial::
 

--- a/content/directives.rst
+++ b/content/directives.rst
@@ -1,46 +1,82 @@
 Directives
 ==========
 
-We have the following directives available:
+**Directives** are used to set off a certain block of text.  They can
+be used as an aside or block (e.g. ``exercise``, ``instructor-note``).
+If the content of the box would be long (e.g. an entire episode is a
+``type-along``, or an entire section is an ``exercise``), you could use
+the ``type-along`` directive to introduce the start of it but not put
+all content in that directive.
 
-* ``callout``
-* ``challenge``
-* ``checklist``
-* ``discussion``
-* ``keypoints``
-* ``objectives``
-* ``prereq``
-* ``solution`` (begins collapsed)
-* ``testimonial``
-* ``output``
-* ``questions``
-* ``instructor-note``
+Sphinx and docutils calls these type of directives **admonitions**
+(and "directive" is a more general concept)
 
 
-Example of ``challenge``:
 
-.. challenge::
+How to use
+----------
+
+Example of ``exercise``:
+
+.. exercise::
 
    Some body text
+
+.. exercise:: Custom title
+
+   Some body text
+
+.. exercise::
 
 .. list-table::
 
    * * Markdown::
 
-         ```{challenge}
+         ```{exercise}
 
          Some body text
          ```
 
+       ::
+
+         ```{exercise} Custom title
+
+         Some body text
+         ```
+
+       ::
+
+         ```{exercise}
+         ```
+
+
+
      * ReST::
 
-	 .. challenge::
+	 .. exercise::
 
 	    Some body text
 
+       ::
+
+	 .. exercise:: Custom title
+
+	    Some body text
+
+       ::
+
+	 .. exercise::
+
+
+You notice these directives can have optional a custom title.  This is
+an addition from regular Sphinx admonitions, and is *not* usable in
+regular Sphinx admonition directives.  Also, unlike regular Sphinx
+admonitions, the content in our directives is optional, if you want to
+use it as a simple section header.
+
 
 The ``solution`` directive begins collapsed (via `sphinx-togglebutton
-<https://github.com/executablebooks/sphinx-togglebutton>`__:
+<https://github.com/executablebooks/sphinx-togglebutton>`__):
 
 .. solution::
 
@@ -49,3 +85,159 @@ The ``solution`` directive begins collapsed (via `sphinx-togglebutton
 Directives are implemented in the Python package
 ``sphinx_lesson.directives`` and can be used independently of the rest
 of ``sphinx-lesson``.
+
+
+
+List
+----
+
+Many directives are available.
+
+The following directives are used for exercises/solutions/homework.
+They all render as green ("important" class:
+
+* ``demo``
+* ``exercise``
+* ``solution`` (toggleable, default hidden)
+* ``type-along`` (most of the lessons are hands-on, so this is a bit
+  redundant.  Use this when emphasizing a certain section is "follow
+  along", as opposed to watching or working alone.)
+* ``homework``
+
+Other miscellaneous directives:
+
+* ``prerequisites``
+* ``instructor-note``
+
+The following are Sphinx default directives that may be especially
+useful to lessons.  These do *not* accept an optional Title argument,
+the title is hard-coded.
+
+* ``see-also``
+* ``note``
+* ``important`` (green)
+* ``warning`` (yellow)
+* ``danger`` (red
+
+
+The following are available, for compatibility with Carpentries styles:
+
+* ``callout``
+* ``challenge`` (alias to ``exercise``)
+* ``checklist``
+* ``discussion``
+* ``keypoints`` (bottom of lesson)
+* ``objectives`` (top of lesson)
+* ``prereq`` (use ``prerequisites`` instead)
+* ``solution`` (begins collapsed)
+* ``testimonial``
+* ``output`` (use code blocks instead)
+* ``questions`` (top of lesson)
+
+
+
+Gallery
+-------
+
+This is a demonstration of all major directives
+
+sphinx-lesson
+~~~~~~~~~~~~~
+
+.. demo::
+
+   demo
+
+.. demo::
+
+.. type-along::
+
+   type-along
+
+.. type-along::
+
+.. exercise::
+
+   exercise
+
+.. solution::
+
+   solution
+
+.. homework::
+
+   homework
+
+.. instructor-note::
+
+   instructor-note
+
+.. prerequisites::
+
+   prerequisites
+
+Sphinx default
+~~~~~~~~~~~~~~
+
+.. note::
+
+   note
+
+.. important::
+
+   important
+
+.. seealso::
+
+   seealso
+
+.. warning::
+
+   warning
+
+.. danger::
+
+   danger
+
+Carpentries holdovers
+~~~~~~~~~~~~~~~~~~~~~
+
+.. questions::
+
+   questions
+
+.. objectives::
+
+   objectives
+
+.. keypoints::
+
+   keypoints
+
+.. callout::
+
+   callout
+
+.. challenge::
+
+   challenge
+
+.. checklist::
+
+   checklist
+
+.. prereq::
+
+   prereq
+
+.. discussion::
+
+   discussion
+
+.. testimonial::
+
+   testimonial
+
+.. output::
+
+   output

--- a/sphinx_lesson/_static/sphinx_lesson.css
+++ b/sphinx_lesson/_static/sphinx_lesson.css
@@ -4,20 +4,26 @@ body.wy-body-for-nav img.with-border {
     border: 2px solid;
 }
 
+.rst-content .admonition-no-content {
+    padding-bottom: 0px;
+}
+
 /* challenge */
-.rst-content .challenge > .admonition-title::before {
-    content: "\01F4DD";  /* Memo */
-}
-
-/* solution */
+.rst-content .demo > .admonition-title::before {
+    content: "\1F441\FE0F";  /* Keyboard */ }
+.rst-content .type-along > .admonition-title::before {
+    content: "\02328";  /* Keyboard */ }
+.rst-content .exercise > .admonition-title::before {
+    content: "\0270D\0FE0F";  /* Hand */ }
 .rst-content .solution > .admonition-title::before {
-    content: "\02714";  /* Check mark */
-}
-
-/* questions */
+    content: "\02714\0FE0E";  /* Check mark */ }
+.rst-content .homework > .admonition-title::before {
+    content: "\01F4DD";  /* Memo */ }
 .rst-content .questions > .admonition-title::before {
-    content: "\02753";  /* Question mark */
-}
+    content: "\02753\0FE0E";  /* Question mark */ }
+.rst-content .seealso > .admonition-title::before {
+    content: "\027A1\0FE0E";  /* Question mark */ }
+
 
 /* instructor-note */
 .rst-content .instructor-note {
@@ -28,4 +34,10 @@ body.wy-body-for-nav img.with-border {
 }
 .rst-content .instructor-note > .admonition-title::before {
     content: "";
+}
+
+
+/* sphinx_toggle_button, make the font white */
+.rst-content .toggle.admonition button.toggle-button {
+    color: white;
 }

--- a/sphinx_lesson/_static/sphinx_lesson.css
+++ b/sphinx_lesson/_static/sphinx_lesson.css
@@ -10,9 +10,9 @@ body.wy-body-for-nav img.with-border {
 
 /* challenge */
 .rst-content .demo > .admonition-title::before {
-    content: "\1F441\FE0F";  /* Keyboard */ }
+    content: "\01F441\0FE0F";  /* Eye */ }
 .rst-content .type-along > .admonition-title::before {
-    content: "\02328";  /* Keyboard */ }
+    content: "\02328\0FE0F";  /* Keyboard */ }
 .rst-content .exercise > .admonition-title::before {
     content: "\0270D\0FE0F";  /* Hand */ }
 .rst-content .solution > .admonition-title::before {

--- a/sphinx_lesson/_static/sphinx_lesson.css
+++ b/sphinx_lesson/_static/sphinx_lesson.css
@@ -23,7 +23,7 @@ body.wy-body-for-nav img.with-border {
 .rst-content .questions > .admonition-title::before {
     content: "\02753\0FE0E";  /* Question mark */ }
 .rst-content .prerequisites > .admonition-title::before {
-    content: "\02699\0FE0F";  /* Gear */ }
+    content: "\02699";  /* Gear */ }
 .rst-content .seealso > .admonition-title::before {
     content: "\027A1\0FE0E";  /* Question mark */ }
 

--- a/sphinx_lesson/_static/sphinx_lesson.css
+++ b/sphinx_lesson/_static/sphinx_lesson.css
@@ -8,9 +8,8 @@ body.wy-body-for-nav img.with-border {
     padding-bottom: 0px;
 }
 
-/* challenge */
 .rst-content .demo > .admonition-title::before {
-    content: "\01F441\0FE0F";  /* Eye */ }
+    content: "\01F440";  /* Eyes */ }
 .rst-content .type-along > .admonition-title::before {
     content: "\02328\0FE0F";  /* Keyboard */ }
 .rst-content .exercise > .admonition-title::before {
@@ -19,8 +18,12 @@ body.wy-body-for-nav img.with-border {
     content: "\02714\0FE0E";  /* Check mark */ }
 .rst-content .homework > .admonition-title::before {
     content: "\01F4DD";  /* Memo */ }
+.rst-content .discussion > .admonition-title::before {
+    content: "\01F4AC";  /* Speech balloon */ }
 .rst-content .questions > .admonition-title::before {
     content: "\02753\0FE0E";  /* Question mark */ }
+.rst-content .prerequisites > .admonition-title::before {
+    content: "\02699\0FE0F";  /* Gear */ }
 .rst-content .seealso > .admonition-title::before {
     content: "\027A1\0FE0E";  /* Question mark */ }
 

--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -14,6 +14,15 @@ from . import __version__
 LOG = getLogger(__name__)
 
 
+def class_name_to_slug(name):
+    """Strip Directive and turn name into slug
+
+    Example:
+      Hands_OnDirective --> hands-on
+    """
+    return name.split('Directive')[0].lower().replace('_', '-')
+
+
 # This includes a heading, to not then have
 class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
     """A directive to handle CodeRefinery styles
@@ -23,16 +32,17 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
     optional_arguments = 1
     final_argument_whitespace = True
     extra_classes = [ ]
+    allow_empty = True
 
     @classmethod
-    def cssname(cls):
+    def get_cssname(cls):
         """Return the CSS class name and Sphinx directive name.
 
         - Remove 'Directive' from the name of the class
         - All lowercase
         - '_' replaced with '-'
         """
-        return cls.__name__.split('Directive')[0].lower().replace('_', '-')
+        return class_name_to_slug(cls.__name__)
 
     def run(self):
         """Run the normal admonition class, but add in a new features.
@@ -41,7 +51,7 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
         CSS level. If this is set, then this title will be added by the
         directive.
         """
-        name = self.cssname()
+        name = self.get_cssname()
         self.node_class = nodes.admonition
         # Some jekyll-common nodes have CSS-generated titles, some don't.  The
         # Admonition class requires a title.  Add one if missing.  The title is
@@ -58,24 +68,57 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
         ret[0].attributes['classes'].extend(self.extra_classes)
         return ret
 
+    def assert_has_content(self):
+        """Allow empty directive blocks.
 
-class CalloutDirective(_BaseCRDirective): pass
-class ChallengeDirective(_BaseCRDirective):
+        This override skis the content check, if self.allow_empty is set
+        to True.  This adds the admonition-no-content to the CSS
+        classes, which reduces a bit of the empty space.  This is a hack
+        of docutils, and may need fixing later on.
+        """
+        if not self.allow_empty:
+            return super().assert_has_content()
+        if not self.content:
+            #if not hasattr(self, 'extra_classes'):
+            #    self.extra_classes = [ ]
+            self.extra_classes = list(self.extra_classes) + ['admonition-no-content']
+        return
+
+
+# These are the priamirly recommend directives
+class DemoDirective(_BaseCRDirective):
+    title_text = "Demo: just watch"
+class Type_AlongDirective(_BaseCRDirective):
     extra_classes = ['important']
-class ChecklistDirective(_BaseCRDirective): pass
-class DiscussionDirective(_BaseCRDirective): pass
-class KeypointsDirective(_BaseCRDirective): pass
-class ObjectivesDirective(_BaseCRDirective): pass
-class PrereqDirective(_BaseCRDirective):
-    title_text = "Prerequisites"
+class ExerciseDirective(_BaseCRDirective):
+    extra_classes = ['important']
 class SolutionDirective(_BaseCRDirective):
     extra_classes = ['important', 'dropdown'] #'toggle-shown' = visible by default
+class HomeworkDirective(_BaseCRDirective):
+    extra_classes = ['important']
+class Instructor_NoteDirective(_BaseCRDirective):
+    title_text = "Instructor note"
+class PrerequisitesDirective(_BaseCRDirective):
+    title_text = "Prerequisites"
+
+# These are hold-over for carpentries
+class QuestionsDirective(_BaseCRDirective):
+    """Used at top of lesson for questions which will be answered"""
+    pass
+class ObjectivesDirective(_BaseCRDirective):
+    """Used at top of lesson"""
+    pass
+class KeypointsDirective(_BaseCRDirective):
+    """Used at bottom of lesson"""
+    pass
+class CalloutDirective(_BaseCRDirective): pass
+ChallengeDirective = ExerciseDirective
+class ChecklistDirective(_BaseCRDirective): pass
+PrereqDirective = PrerequisitesDirective
+class DiscussionDirective(_BaseCRDirective): pass
 class TestimonialDirective(_BaseCRDirective): pass
 class OutputDirective(_BaseCRDirective):
     title_text = 'Output'
-class QuestionsDirective(_BaseCRDirective): pass
-class Instructor_NoteDirective(_BaseCRDirective):
-    title_text = "Instructor note"
 
 # This does work, to add
 # from sphinx.writers.html5 import HTML5Translator
@@ -101,8 +144,9 @@ def setup(app):
         if (name.endswith('Directive')
             and issubclass(obj, _BaseCRDirective)
             and not name.startswith('_')):
-            #print(name, obj.cssname())
-            app.add_directive(obj.cssname(), obj)
+            #print(name, obj.get_cssname())
+            directive_name = class_name_to_slug(name)
+            app.add_directive(directive_name, obj)
 
     # Add CSS to build
     # Hint is from https://github.com/choldgraf/sphinx-copybutton/blob/master/sphinx_copybutton/__init__.py  # pylint: ignore=E501

--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -71,7 +71,7 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
     def assert_has_content(self):
         """Allow empty directive blocks.
 
-        This override skis the content check, if self.allow_empty is set
+        This override skips the content check, if self.allow_empty is set
         to True.  This adds the admonition-no-content to the CSS
         classes, which reduces a bit of the empty space.  This is a hack
         of docutils, and may need fixing later on.

--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -100,6 +100,8 @@ class Instructor_NoteDirective(_BaseCRDirective):
     title_text = "Instructor note"
 class PrerequisitesDirective(_BaseCRDirective):
     title_text = "Prerequisites"
+class DiscussionDirective(_BaseCRDirective):
+    extra_classes = ['attention']
 
 # These are hold-over for carpentries
 class QuestionsDirective(_BaseCRDirective):
@@ -115,7 +117,6 @@ class CalloutDirective(_BaseCRDirective): pass
 ChallengeDirective = ExerciseDirective
 class ChecklistDirective(_BaseCRDirective): pass
 PrereqDirective = PrerequisitesDirective
-class DiscussionDirective(_BaseCRDirective): pass
 class TestimonialDirective(_BaseCRDirective): pass
 class OutputDirective(_BaseCRDirective):
     title_text = 'Output'

--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -87,7 +87,7 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
 
 # These are the priamirly recommend directives
 class DemoDirective(_BaseCRDirective):
-    title_text = "Demo: just watch"
+    title_text = "Demo"
 class Type_AlongDirective(_BaseCRDirective):
     extra_classes = ['important']
 class ExerciseDirective(_BaseCRDirective):


### PR DESCRIPTION
- Standardize and color directives as described in #45
- Give various emojis to directives, but not to every one.
- Allow directive content to be empty
  - This requires non-trivial (but not too difficult) changes, and may
    introduce some maintenance burden.  It may also cause some
    incompatility with other themes, but probably not much more than
    we already get by our particular styling.
- Improve documentation
  - List all directives, how they work, and recommended uses.
  - Have a gallery of all directives
- Do not remove carpentries-compatibility directives (and do list
  them).
- Review:
  - Read #45, and compare these results to that.
  - Is this a good implementation?  Good directive names?
  - Decide if there is anything to remove or add.
  - Is the "empty content" a good idea?
  - Are the colors good?  (can be improved late)
- Future
  - Change the sample lesson template to use this.