### PR TITLE
Added a hint when `python3` does not work

### DIFF
--- a/content/contributing-to-a-lesson.rst
+++ b/content/contributing-to-a-lesson.rst
@@ -88,6 +88,10 @@ environment would work just as well)::
   $ python3 -m venv venv/
   $ source venv/bin/activate
 
+.. note::
+
+   if ``python3 -m venv venv/``does not work, try with ``python -m venv venv/
+
 Then install dependencies inside::
 
   $ pip install -r requirements.txt

--- a/content/contributing-to-a-lesson.rst
+++ b/content/contributing-to-a-lesson.rst
@@ -90,7 +90,7 @@ environment would work just as well)::
 
 .. note::
 
-   if ``python3 -m venv venv/``does not work, try with ``python -m venv venv/
+   if ``python3 -m venv venv/`` does not work, try with ``python -m venv venv/``
 
 Then install dependencies inside::
 


### PR DESCRIPTION
It seems that in some cases use of `python -m venv venv/` instead of `python3`works, so I suggest to add this note. Not sure if the note syntax is successfully rendered (not tried previewing locally), so modify to make it correct. Thanks!