### PR TITLE
sphinx_lesson/directives: cssname vs get_cssname backwards compat

### DIFF
--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -46,11 +46,12 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
         return class_name_to_slug(cls.__name__)
     @classmethod
     def cssname(cls):
-          warnings.warn(
-            "You should use `get_cssname` (#71, 2021-08-22) and update old code to use it. This may be removed someday.\n" ,
+        """Backwards compatibility for get_cssname, do not use."""
+        warnings.warn(
+            "You should use `get_cssname` (#71, 2021-08-22) and update old code to use it. This may be removed someday.\n",
             category=FutureWarning,
             stacklevel=2)
-            return get_cssname(cls)
+        return get_cssname(cls)
 
     def run(self):
         """Run the normal admonition class, but add in a new features.

--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -3,6 +3,7 @@
 # pylint: disable=E701
 
 import os
+import warnings
 
 from docutils import nodes
 from docutils.parsers.rst.directives.admonitions \

--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -43,6 +43,9 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
         - '_' replaced with '-'
         """
         return class_name_to_slug(cls.__name__)
+    # Backwards compatibility (#71, 2021-08-22).  You should use get_cssname
+    # and update old code to use it.  This may be removed someday.
+    cssname = get_cssname
 
     def run(self):
         """Run the normal admonition class, but add in a new features.

--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -43,9 +43,13 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
         - '_' replaced with '-'
         """
         return class_name_to_slug(cls.__name__)
-    # Backwards compatibility (#71, 2021-08-22).  You should use get_cssname
-    # and update old code to use it.  This may be removed someday.
-    cssname = get_cssname
+    @classmethod
+    def cssname(cls):
+          warnings.warn(
+            "You should use `get_cssname` (#71, 2021-08-22) and update old code to use it. This may be removed someday.\n" ,
+            category=FutureWarning,
+            stacklevel=2)
+            return get_cssname(cls)
 
     def run(self):
         """Run the normal admonition class, but add in a new features.


### PR DESCRIPTION
- Some people deriving from this have already use .cssname(), so we
  should make life easy and continue to support that.
- Closes: #71
- Review: general check