### PR TITLE
css: for sphinx-togglebutton, remove buffer space in collapsed admonitions

### DIFF
--- a/sphinx_lesson/_static/sphinx_lesson.css
+++ b/sphinx_lesson/_static/sphinx_lesson.css
@@ -44,3 +44,8 @@ body.wy-body-for-nav img.with-border {
 .rst-content .toggle.admonition button.toggle-button {
     color: white;
 }
+
+/* sphinx-togglebutton, remove underflow when toggled to hidden mode */
+.rst-content .admonition.toggle-hidden {
+    padding-bottom: 0px;
+}


### PR DESCRIPTION
- With sphinx_rtd_theme, when an admonition (sphinx-lesson
  terminology: directive) is toggled closed, there is a small amount
  of padding at the bottom, where content would be.

- This CSS change removes that padding.

- This is designed to be relatively safe for other themes... but who
  knows, it needs checking.  This will be done before merging.
