### PR TITLE
Add exercise list directive

### DIFF
--- a/content/exercise-list.rst
+++ b/content/exercise-list.rst
@@ -1,0 +1,38 @@
+Exercise list
+=============
+
+The ``exercise-list`` directive inserts a list of all exercises.  This
+can be useful as an overall summary of the entire lesson flow,
+onboarding new instructors and helpers, and more.
+
+ReST::
+
+  .. exerciselist::
+
+MyST::
+
+  ```{exerciselist}```
+
+Note that it includes the page names, links to the exercises, and the
+exercise directive contents itself.  Note that the context is missing,
+so it is important to give a good name to the exercise so that it
+makes sense to a reader.  An example of an exercise with a title::
+
+  .. exercise:: Demonstrate basic addition
+
+     What is 1+1?
+
+This feature is new as of early 2022, there may be possible problems
+in it still - please report.
+
+
+
+Example
+-------
+
+This section contains the exercise list of sphinx-lesson.  Note that
+the directives occur many times in random contexts, so many of them
+don't really make sense.  Keep in mind how to ensure that your cases
+are better.
+
+.. exerciselist::

--- a/content/index.rst
+++ b/content/index.rst
@@ -84,6 +84,7 @@ refinement work to go.
    gh-action
    presentation-mode
    indexing
+   exercise-list
    convert-old-lessons
 
 .. toctree::

--- a/content/installation.rst
+++ b/content/installation.rst
@@ -40,6 +40,7 @@ Adding ``sphinx_lesson`` as an extension adds these sub-extensions:
 
   * ``sphinx_lesson.directives`` - see :doc:`directives`.
   * ``sphinx_lesson.md_transforms`` - see :doc:`md-transforms`.
+  * ``sphinx_lesson.exerciselist`` - see :doc:`exercise-list`.
   * Enables the `myst_notebook extension
     <https://myst-nb.readthedocs.io/en/latest/>`__, which also enables
     `myst_parser

--- a/sphinx_lesson/__init__.py
+++ b/sphinx_lesson/__init__.py
@@ -9,6 +9,7 @@ def setup(app):
     app.setup_extension('sphinx_togglebutton')
     app.setup_extension(__name__+'.directives')
     app.setup_extension(__name__+'.md_transforms')
+    app.setup_extension(__name__+'.exerciselist')
 
     return {
         'version': __version__,

--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -75,6 +75,12 @@ class _BaseCRDirective(AdmonitionDirective, SphinxDirective):
         # Set CSS classes
         ret[0].attributes['classes'].append(name)
         ret[0].attributes['classes'].extend(self.extra_classes)
+        # Give it a reference
+        target_id = name+'-%d' % self.env.new_serialno(name)
+        targetnode = nodes.target('', '', ids=[target_id])
+        ret[0].target_id = target_id
+        ret[0].target_docname = self.env.docname
+        ret.insert(0, targetnode)
         return ret
 
     def assert_has_content(self):

--- a/sphinx_lesson/exerciselist.py
+++ b/sphinx_lesson/exerciselist.py
@@ -79,7 +79,7 @@ def process_exerciselist_nodes(app, doctree, fromdocname):
             par = nodes.paragraph()
 
             # Create a reference
-            newnode = nodes.reference(f'At {filename}:', f'At {filename}:')
+            newnode = nodes.reference(f'In {filename}:', f'In {filename}:')
             newnode['refdocname'] = exercise_node.target_docname
             newnode['refuri'] = app.builder.get_relative_uri(
                 fromdocname, exercise_node.target_docname)

--- a/sphinx_lesson/exerciselist.py
+++ b/sphinx_lesson/exerciselist.py
@@ -2,8 +2,13 @@ import re
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
+import sphinx.util
 
 class exerciselist(nodes.General, nodes.Element):
+    """Node for exercise list
+
+    Gets replaced with contents in the second pass.
+    """
     pass
 
 class ExerciselistDirective(Directive):
@@ -23,7 +28,6 @@ def find_exerciselist_nodes(app, env):
 
     # Find all docnames in toctree order.
     docnames = [ ]
-    root_docname = next(iter(env.toctree_includes))
     def process_docname(docname):
         """Process this doc and children"""
         if docname in docnames: # already visited
@@ -31,7 +35,12 @@ def find_exerciselist_nodes(app, env):
         docnames.append(docname)
         for docname2 in env.toctree_includes.get(docname, []):  # children
             process_docname(docname2)
-    process_docname(root_docname)
+    root_doc = app.config.root_doc
+    if root_doc not in env.toctree_includes:
+        logger = sphinx.util.logging.getLogger(__name__)
+        logger.error(f'sphinx_lesson.exerciselist could not find root doc {root_doc}')
+        return
+    process_docname(root_doc)
 
     # The list of all the exercises will be stored here.
     if not hasattr(env, 'sphinx_lesson_all_exercises'):

--- a/sphinx_lesson/exerciselist.py
+++ b/sphinx_lesson/exerciselist.py
@@ -1,0 +1,102 @@
+import re
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+class exerciselist(nodes.General, nodes.Element):
+    pass
+
+class ExerciselistDirective(Directive):
+    def run(self):
+        return [exerciselist('')]
+
+
+def find_exerciselist_nodes(app, env):
+    """Find all nodes for the exercise list, in order.
+
+    Go through all documents (in toctree order) and make a list of all
+    docnames.  Then, from those docnames, find all admonitions that
+    match certain classes.  Store this for the next round.
+    """
+
+    env = app.builder.env
+
+    # Find all docnames in toctree order.
+    docnames = [ ]
+    root_docname = next(iter(env.toctree_includes))
+    def process_docname(docname):
+        """Process this doc and children"""
+        if docname in docnames: # already visited
+            return
+        docnames.append(docname)
+        for docname2 in env.toctree_includes.get(docname, []):  # children
+            process_docname(docname2)
+    process_docname(root_docname)
+
+    # The list of all the exercises will be stored here.
+    if not hasattr(env, 'sphinx_lesson_all_exercises'):
+        env.sphinx_lesson_all_exercises = [ ]
+    all_exercises = env.sphinx_lesson_all_exercises
+
+    # Now go through and collect all admonitions from these docnames, in order.
+    for docname in docnames:
+        doctree = env.get_doctree(docname)
+        for node in doctree.traverse(nodes.admonition):
+            classes = node.attributes.get('classes', ())
+            if {'exercise', 'solution'}.intersection(classes):
+                all_exercises.append(node)
+
+
+def process_exerciselist_nodes(app, doctree, fromdocname):
+    """Find 'exerciselist' directives and replace with the exercise list.
+    """
+    env = app.builder.env
+    # List of exercises
+    if not hasattr(env, 'sphinx_lesson_all_exercises'):
+        env.sphinx_lesson_all_exercises = [ ]
+    all_exercises = env.sphinx_lesson_all_exercises
+
+    for exerciselist_node in doctree.traverse(exerciselist):
+        content = []  # This new content in place of 'exerciselist'
+        last_docname = None
+        for exercise_node in all_exercises:
+            # Set title of the document.  We need to make a new section with a
+            # 'title' node for this.
+            if exercise_node.target_docname != last_docname:
+                # find the page title
+                last_docname = exercise_node.target_docname
+                doctree = env.get_doctree(exercise_node.target_docname)
+                page_title = next(iter(doctree.traverse(nodes.title)))
+                # make section with the stuff
+                section = nodes.section()
+                content.append(section)
+                section += page_title
+                slug = page_title.rawsource.replace(' ', '-').lower()
+                slug = re.sub(r'[^\w\d_-]', '', slug)
+                section['ids'].append(slug)
+
+            filename = env.doc2path(exercise_node.target_docname, base=None)
+            par = nodes.paragraph()
+
+            # Create a reference
+            newnode = nodes.reference(f'At {filename}:', f'At {filename}:')
+            newnode['refdocname'] = exercise_node.target_docname
+            newnode['refuri'] = app.builder.get_relative_uri(
+                fromdocname, exercise_node.target_docname)
+            newnode['refuri'] += '#' + exercise_node.target_id
+            par += newnode
+            section.append(par)
+            section.append(exercise_node)
+
+        exerciselist_node.replace_self(content)
+
+def setup(app):
+    app.add_node(exerciselist)
+    app.add_directive('exerciselist', ExerciselistDirective)
+    app.connect('env-check-consistency', find_exerciselist_nodes)
+    app.connect('doctree-resolved', process_exerciselist_nodes)
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
- Add as exercise list directive, as we have found useful for review a lesson and onboarding helpers.
- parses the document, finds the nodes, and adds them to the
- This isn't perfect, but maybe good enough to go and start using for now, and then improve?

For putting it into production (or even testing production), my thought is it is simplest to make a release, and then update our lessons.  I think there should be little risk of breaking lessons that don't use it.