### PR TITLE
exerciselist: exclude nodes whose parent is included

### DIFF
--- a/content/sample-episode-rst.rst
+++ b/content/sample-episode-rst.rst
@@ -86,6 +86,18 @@ in the table of contents.
    * Solution to that one.
 
 
+.. challenge:: Exercise with embedded solution
+
+   2. Similarly, each exercise has a quick description title ``Create
+      a lesson`` in bold.  These titles are useful so that helpers
+      (and learners...) can quickly understand what the point is.
+
+   .. solution::
+
+      * Solution to that one.
+
+
+
 
 Another section
 ---------------

--- a/sphinx_lesson/exerciselist.py
+++ b/sphinx_lesson/exerciselist.py
@@ -22,6 +22,24 @@ class ExerciselistDirective(Directive):
         return [exerciselist('')]
 
 
+def is_exercise_node(node):
+    """Should a single node be included in the exercise list?"""
+    # If not an admonition, never include
+    if not isinstance(node, nodes.admonition):
+        return False
+    # If wrong classes, exclude
+    if not hasattr(node, 'attributes'):
+        return False
+    classes = node.attributes.get('classes', ())
+    if not DEFAULT_EXERCISELIST_CLASSES.intersection(classes):
+        return False
+    # If parent is included, we don't need to include us.
+    # TODO: higher level parents
+    if hasattr(node, 'parent') and is_exercise_node(node.parent):
+        #import pdb ; pdb.set_trace()
+        return False
+    return True
+
 def find_exerciselist_nodes(app, env):
     """Find all nodes for the exercise list, in order.
 
@@ -57,8 +75,7 @@ def find_exerciselist_nodes(app, env):
     for docname in docnames:
         doctree = env.get_doctree(docname)
         for node in doctree.traverse(nodes.admonition):
-            classes = node.attributes.get('classes', ())
-            if DEFAULT_EXERCISELIST_CLASSES.intersection(classes):
+            if is_exercise_node(node):
                 all_exercises.append(node)
 
 


### PR DESCRIPTION
- This prevents duplicate solutions in the list, when a solution is
  included as part of the exercise, and as a separate one.
- Not yet perfect, it doesn't look at higher level parents.
- Review: does CI pass?  Test with another lesson or two.
