### PR TITLE
exerciselist: Support sphinx<4.0, which uses master_doc instead of root_doc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@
 name: test
 on: [push, pull_request]
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -21,9 +21,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install sphinx${{matrix.sphinx_version}}
-          pip install .
+          pip install sphinx${{matrix.sphinx_version}} -r requirements.txt .
       - name: List dependency versions
         run: |
           python -V

--- a/sphinx_lesson/exerciselist.py
+++ b/sphinx_lesson/exerciselist.py
@@ -59,7 +59,8 @@ def find_exerciselist_nodes(app, env):
         docnames.append(docname)
         for docname2 in env.toctree_includes.get(docname, []):  # children
             process_docname(docname2)
-    root_doc = app.config.root_doc
+    # Sphinx 4.0 renamed master_doc > root_doc
+    root_doc = app.config.root_doc if hasattr(app.config, 'root_doc') else app.config.master_doc
     if root_doc not in env.toctree_includes:
         logger = sphinx.util.logging.getLogger(__name__)
         logger.error(f'sphinx_lesson.exerciselist could not find root doc {root_doc}')


### PR DESCRIPTION
- Sphinx 4.0 renamed master_doc to root_doc, so exerciselist didn't
  work on that earlier version.
- The Github Action actually does try to test for earlier versions,
  but it seems like it does n't successfully install the older Sphinx
  versions for the tests.  Re-adjust the action to install everything
  at once, in hopes that this works.  A local test implies that it
  might.
- Closes: #84
- Review:
  - does CI pass?
  - Check the action output "List dependency version" log and verify
    that it's testing older sphinx versions.
