### PR TITLE
content/sample-episode-rst: Fix 'pending_xref' error with links in exercise list

### DIFF
--- a/content/exercise-list.rst
+++ b/content/exercise-list.rst
@@ -19,6 +19,8 @@ in it still - please report.
 
 
 
+.. _exerciselist_recommendations:
+
 Recommendations to make a useful list
 -------------------------------------
 

--- a/content/sample-episode-rst.rst
+++ b/content/sample-episode-rst.rst
@@ -65,7 +65,7 @@ Exercise: the general topic
 Exercises get their own section, so that they can be linked and found
 in the table of contents.
 
-.. challenge:: 1.1 Exercise title
+.. exercise:: 1.1 Exercise title
 
    1. Notice the exercise set has both an ID and
       number ``SampleLesson-1`` and description of what it contains.
@@ -75,7 +75,7 @@ in the table of contents.
    * Solution here.
 
 
-.. challenge:: 1.2 Create a lesson
+.. exercise:: 1.2 Create a lesson
 
    2. Similarly, each exercise has a quick description title ``Create
       a lesson`` in bold.  These titles are useful so that helpers
@@ -86,7 +86,7 @@ in the table of contents.
    * Solution to that one.
 
 
-.. challenge:: Exercise with embedded solution
+.. exercise:: Exercise with embedded solution
 
    2. Similarly, each exercise has a quick description title ``Create
       a lesson`` in bold.  These titles are useful so that helpers
@@ -96,6 +96,10 @@ in the table of contents.
 
       * Solution to that one.
 
+.. exercise:: Exercise with embedded solution
+
+   3. Exercise with a :doc:`link <index>`, or :ref:`internal reference
+      <exerciselist_recommendations>`.
 
 
 

--- a/sphinx_lesson/exerciselist.py
+++ b/sphinx_lesson/exerciselist.py
@@ -118,7 +118,7 @@ def process_exerciselist_nodes(app, doctree, fromdocname):
             newnode['refuri'] += '#' + exercise_node.target_id
             par += newnode
             section.append(par)
-            section.append(exercise_node)
+            section.append(exercise_node.copy())
 
         exerciselist_node.replace_self(content)
 


### PR DESCRIPTION
- If we make a copy of the nodes we re-insert
  (`exercise_node.copy()`), the error goes away.
- Interestingly, the error stays when you use either
  `exercise_node.deepcopy()` or `copy.deepcopy(exercise_node)`.
- First pushing without the fix to ensure CI sees the error, then will
  force-push with the fix.
- Closes: #83
- Review:
  - If anyone knows sphinx/docutils well, take a look.  But
    realistically, that may be no one so merge if CI passes.
