### PR TITLE
exerciselist: allow selecting admonitions to include/exclude

### DIFF
--- a/content/exercise-list.rst
+++ b/content/exercise-list.rst
@@ -32,7 +32,9 @@ admonition classes to include (default: ``exercise``, ``solution``,
      :class: exclude-this
 
 This feature is new as of early 2022, there may be possible problems
-in it still - please report.
+in it still - please report.  Currently, only sphinx-lesson
+admonitions can be included due to technical considerations (see
+source for hint on fixing).
 
 
 

--- a/content/exercise-list.rst
+++ b/content/exercise-list.rst
@@ -1,9 +1,13 @@
 Exercise list
 =============
 
-The ``exercise-list`` directive inserts a list of all exercises.  This
-can be useful as an overall summary of the entire lesson flow,
-onboarding new instructors and helpers, and more.
+The ``exercise-list`` directive inserts a list of all exercise and
+solution :doc:`directives <directives>` (and maybe more).  This can be
+useful as an overall summary of the entire lesson flow, onboarding new
+instructors and helpers, and more.
+
+Usage
+-----
 
 ReST::
 
@@ -13,6 +17,19 @@ MyST::
 
   ```{exerciselist}```
 
+One can give the optional directive arguments to specify lists of
+admonition classes to include (default: ``exercise``, ``solution``,
+``exerciselist-include``) or exclude (default:
+``exerciselist-exclude``) if you want to (any :doc:`directives
+<directives>` which match any ``include``, and do not match any
+``exclude`` are included).  Specify the options this way (ReST)::
+
+  .. exerciselist::
+     :include: exercise solution instructor-note
+     :exclude: exclude-this
+
+  .. exercise::
+     :class: exclude-this
 
 This feature is new as of early 2022, there may be possible problems
 in it still - please report.
@@ -72,6 +89,11 @@ Recommendations to make a useful list
 - Optional or advanced exercises should clearly state it in the
   exercise title, since people will browse the list separate from the
   main lesson material.
+
+- Try to minimize use of ``:include:`` and ``:exclude:`` and use the
+  defaults and adjust your directives to match sphinx-lesson
+  semantics.  Excess use of this may over-optimize for particular
+  workshops
 
 
 Example

--- a/sphinx_lesson/exerciselist.py
+++ b/sphinx_lesson/exerciselist.py
@@ -4,6 +4,9 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 import sphinx.util
 
+# Currently only sphinx-lesson admonitions can be included. Hint to fix:
+# nodes.admonition to nodes.Admonition and then you have to examine the Python
+# object class name.
 DEFAULT_EXERCISELIST_CLASSES = {
     'exercise',
     'solution',
@@ -35,9 +38,9 @@ class ExerciselistDirective(Directive):
     def run(self):
         kwargs = { }
         if 'include' in self.options:
-            kwargs['include_clasess'] = self.options['include'].split()
+            kwargs['include_classes'] = re.split('[ ,]+', self.options['include'])
         if 'exclude' in self.options:
-            kwargs['exclude_classes'] = self.options['exclude'].split()
+            kwargs['exclude_classes'] = re.split('[ ,]+', self.options['exclude'])
         el = exerciselist('', **kwargs)
         return [el]
 


### PR DESCRIPTION
- Allow a user to specify which admonitions should be inlcuded or
  excluded
- Also refactors the exerciselist mechanics to make this possible,
  which allows for each exercise list to be different.
- Review: check docs, I'll look at this again and merge
