### PR TITLE
content/sample-episode-rst: Add `discussion` example

### DIFF
--- a/content/sample-episode-rst.rst
+++ b/content/sample-episode-rst.rst
@@ -73,6 +73,10 @@ A code block with preceeding paragraph::
       library(x)
       a <- 1 + 2
 
+.. discussion:: This is a `discussion` directive
+
+   Discussion content.
+
 
 Exercise: [the general topic]
 -----------------------------


### PR DESCRIPTION
- A example of the discussion directive was missing from the sample
  episode.
- Review: automerge
