### PR TITLE
directives: Derive the discussion directive from 'important', not 'attention'

### DIFF
--- a/sphinx_lesson/directives.py
+++ b/sphinx_lesson/directives.py
@@ -116,7 +116,7 @@ class Instructor_NoteDirective(_BaseCRDirective):
 class PrerequisitesDirective(_BaseCRDirective):
     title_text = "Prerequisites"
 class DiscussionDirective(_BaseCRDirective):
-    extra_classes = ['attention']
+    extra_classes = ['important']
 
 # These are hold-over for carpentries
 class QuestionsDirective(_BaseCRDirective):


### PR DESCRIPTION
- Right now, the `discussion` directive is derived from `attention`,
  so is **yellow*.
- Most other directives that want you to actively do something are
  **green** (derived from 'important') - and this was the idea.
- I think it makes more sense for `discussion` to be the "do
  something" color (green like exercises) rather than yellow like
  `warning`/`attention`.  This makes that change
- Review:
  - Check out the directive gallery
    (https://coderefinery.github.io/sphinx-lesson/directives/#gallery)
    and see if `discussion` should rather be green, rather than
    yellow.
  - For reasoning of the current color scheme, read
    https://coderefinery.github.io/sphinx-lesson/directives/#gallery
