### PR TITLE
Fix sphinx 5.0 ignoring :std:doc: links by default

### DIFF
--- a/content/indexing.rst
+++ b/content/indexing.rst
@@ -104,7 +104,7 @@ There are different styles:
 Glossaries
 ----------
 
-If you make a glossary using the :std:doc:`glossary directive
+If you make a glossary using the :rst:dir:`glossary directive
 <glossary>`, the terms automatically get added to the index
 
 
@@ -113,4 +113,4 @@ See also
 --------
 
 * :rst:dir:`index` directive
-* Sphinx :std:doc:`glossary`
+* Sphinx :rst:dir:`glossary`

--- a/content/intersphinx.rst
+++ b/content/intersphinx.rst
@@ -5,8 +5,8 @@ There is a common problem: you want to link to documentation in other
 sites, for example the documentation of ``list.sort``.  Isn't it nice
 to have a structured way to do this so you don't have to a) look up a
 URL yourself b) risk having links break?  Well, what do you know,
-Sphinx has a native solution for this: :std:doc:`Intersphinx
-<usage/extensions/intersphinx>`.
+Sphinx has a native solution for this: :py:mod:`Intersphinx
+<sphinx.ext.intersphinx>`.
 
 
 
@@ -23,7 +23,7 @@ commented out.  Enable it:
     }
 
 Configuration details and how to link to other sites are found at
-:std:doc:`the docs for intersphinx <usage/extensions/intersphinx>`.
+:py:mod:`the docs for intersphinx <sphinx.ext.intersphinx>`.
 For most Sphinx-documented projects, use the URL of the documentation
 base.  See "Usage" below for how to verify the URLs.
 
@@ -96,4 +96,4 @@ See also
 
 * :std:doc:`Sphinx: domains <usage/restructuredtext/domains>` - how to
   document classes/functions to be referrable this way, and link to them.
-* :std:doc:`Intersphinx <usage/extensions/intersphinx>`.
+* :py:mod:`Intersphinx <sphinx.ext.intersphinx>`.

--- a/content/intersphinx.rst
+++ b/content/intersphinx.rst
@@ -71,7 +71,7 @@ common roles in the Python domain are:
 * ``:py:data:``: modules, e.g. :py:data:`datetime.MINYEAR`
 * Also ``:py:exc:``, ``:py:data:``, ``:py:obj:``, ``::``, ``::``
 * There are also built-in domains for C, C++, JavaScript (see
-  :std:doc:`usage/restructuredtext/domains` for what the roles are).
+  :external+sphinx:std:doc:`usage/restructuredtext/domains` for what the roles are).
   Others are  added by Sphinx extensions.
 
 You can list all available reference targets at some doc using a
@@ -94,6 +94,6 @@ yourself.
 See also
 --------
 
-* :std:doc:`Sphinx: domains <usage/restructuredtext/domains>` - how to
+* :external+sphinx:std:doc:`Sphinx: domains <usage/restructuredtext/domains>` - how to
   document classes/functions to be referrable this way, and link to them.
 * :py:mod:`Intersphinx <sphinx.ext.intersphinx>`.


### PR DESCRIPTION
- To avoid confusing, Sphinx 5.0 avoids looking up documents in other
  projects with a role of `:std:doc:`.  What this means that if you
  link to `` :std:doc:`glossary` ``, it might accidentally link to
  `glossary` in one of the external projects.  The new idea is that
  you wouldn't usually want to link directly to an external page (this
  is not symbolic and could be rearranged at any time).  Instead, link
  to the symbolic description, e.g. `` :rst:dir:`glossary` ``.  The
  exactly function/directive/etc. is a stable link which is good to
  link to.  (you could say this is the same reason we don't want to
  use raw HTML links)
- Change the few :std:doc: external links to the rst directives that
  we *actually* meant to link to.
- This change should work in older Sphinx just as well.  This was
  probably the better option when I was first adding this, too.
- Review: merge if tests pass.
