### PR TITLE
requirements: Prohibit Sphinx 5.2.0.post0

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.x'
       # https://docs.github.com/en/actions/guides/building-and-testing-python#caching-dependencies
       # ^-- How to set up caching for pip on Ubuntu
       - name: Cache pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        sphinx_version: ["", "~=3.0.0", "~=2.4.0", "~=2.1.0"]
-        python_version: ["3.6", "3.8"]
+        sphinx_version: ["", "~=4.0.0" "~=3.0.0"]
+        python_version: ["3.6", "3.8", '3.x']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/content/conf.py
+++ b/content/conf.py
@@ -49,10 +49,10 @@ extensions = [
 
 # Settings for myst_nb:
 # https://myst-nb.readthedocs.io/en/latest/use/execute.html#triggering-notebook-execution
-#jupyter_execute_notebooks = "off"
-#jupyter_execute_notebooks = "auto"   # *only* execute if at least one output is missing.
-#jupyter_execute_notebooks = "force"
-jupyter_execute_notebooks = "cache"
+#nb_execution_mode = "off"
+#nb_execution_mode = "auto"   # *only* execute if at least one output is missing.
+#nb_execution_mode = "force"
+nb_execution_mode = "cache"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/content/indexing.rst
+++ b/content/indexing.rst
@@ -104,7 +104,7 @@ There are different styles:
 Glossaries
 ----------
 
-If you make a glossary using the :std:doc:`glossary directive
+If you make a glossary using the :rst:dir:`glossary directive
 <glossary>`, the terms automatically get added to the index
 
 
@@ -113,4 +113,4 @@ See also
 --------
 
 * :rst:dir:`index` directive
-* Sphinx :std:doc:`glossary`
+* Sphinx :rst:dir:`glossary`

--- a/content/intersphinx.rst
+++ b/content/intersphinx.rst
@@ -5,8 +5,8 @@ There is a common problem: you want to link to documentation in other
 sites, for example the documentation of ``list.sort``.  Isn't it nice
 to have a structured way to do this so you don't have to a) look up a
 URL yourself b) risk having links break?  Well, what do you know,
-Sphinx has a native solution for this: :std:doc:`Intersphinx
-<usage/extensions/intersphinx>`.
+Sphinx has a native solution for this: :py:mod:`Intersphinx
+<sphinx.ext.intersphinx>`.
 
 
 
@@ -23,7 +23,7 @@ commented out.  Enable it:
     }
 
 Configuration details and how to link to other sites are found at
-:std:doc:`the docs for intersphinx <usage/extensions/intersphinx>`.
+:py:mod:`the docs for intersphinx <sphinx.ext.intersphinx>`.
 For most Sphinx-documented projects, use the URL of the documentation
 base.  See "Usage" below for how to verify the URLs.
 
@@ -71,7 +71,7 @@ common roles in the Python domain are:
 * ``:py:data:``: modules, e.g. :py:data:`datetime.MINYEAR`
 * Also ``:py:exc:``, ``:py:data:``, ``:py:obj:``, ``::``, ``::``
 * There are also built-in domains for C, C++, JavaScript (see
-  :std:doc:`usage/restructuredtext/domains` for what the roles are).
+  :external+sphinx:std:doc:`usage/restructuredtext/domains` for what the roles are).
   Others are  added by Sphinx extensions.
 
 You can list all available reference targets at some doc using a
@@ -94,6 +94,6 @@ yourself.
 See also
 --------
 
-* :std:doc:`Sphinx: domains <usage/restructuredtext/domains>` - how to
+* :external+sphinx:std:doc:`Sphinx: domains <usage/restructuredtext/domains>` - how to
   document classes/functions to be referrable this way, and link to them.
-* :std:doc:`Intersphinx <usage/extensions/intersphinx>`.
+* :py:mod:`Intersphinx <sphinx.ext.intersphinx>`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx!=5.2.0.post0    # remove after next release
 sphinx_rtd_theme
 sphinx_copybutton
 sphinx_minipres


### PR DESCRIPTION
- A four-part version fails with sphinx_rtd_theme:
  https://github.com/readthedocs/sphinx_rtd_theme/issues/1343 While
  this is a problem with sphinx_rtd_theme, the easiest solution is to
  limit Sphinx version (sphinx_rtd_theme updates *slowly*)
- This should be reverted after either sphinx releases again with a
  more normal version number, or sphinx_rtd_theme updates.
- Review: see if CI passes
