### PR TITLE
content/conf: jupyter_execute_notebooks -> nb_execution_mode

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -49,10 +49,10 @@ extensions = [
 
 # Settings for myst_nb:
 # https://myst-nb.readthedocs.io/en/latest/use/execute.html#triggering-notebook-execution
-#jupyter_execute_notebooks = "off"
-#jupyter_execute_notebooks = "auto"   # *only* execute if at least one output is missing.
-#jupyter_execute_notebooks = "force"
-jupyter_execute_notebooks = "cache"
+#nb_execution_mode = "off"
+#nb_execution_mode = "auto"   # *only* execute if at least one output is missing.
+#nb_execution_mode = "force"
+nb_execution_mode = "cache"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
- This is the new option name, and since we run with strict mode
  (warnings become errors) we need to fix this.
- This doesn't affect lessons since they don't get built in strict
  mode.
- This requires myst_nb 0.16.0 (2022-06-13)
- Review: must be used as part of other changes to make CI pass
