### PR TITLE
CI: Update versions used to test

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.x'
       # https://docs.github.com/en/actions/guides/building-and-testing-python#caching-dependencies
       # ^-- How to set up caching for pip on Ubuntu
       - name: Cache pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        sphinx_version: ["", "~=3.0.0", "~=2.4.0", "~=2.1.0"]
-        python_version: ["3.6", "3.8"]
+        sphinx_version: ["", "~=4.0.0" "~=3.0.0"]
+        python_version: ["3.6", "3.8", '3.x']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
- python 3.6, 3.8, latest (3.10 right now)
- sphinx 3.0 and greater (5.0 was just released)
- Review: this will be merged as part of another change
