### PR TITLE
Fix link to MyST notebook execution modes

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -48,7 +48,7 @@ extensions = [
 ]
 
 # Settings for myst_nb:
-# https://myst-nb.readthedocs.io/en/latest/use/execute.html#triggering-notebook-execution
+# https://myst-nb.readthedocs.io/en/latest/computation/execute.html#notebook-execution-modes
 #nb_execution_mode = "off"
 #nb_execution_mode = "auto"   # *only* execute if at least one output is missing.
 #nb_execution_mode = "force"


### PR DESCRIPTION
This fixes the link to the MyST execution modes in comments of conf.py file.